### PR TITLE
Fixes #16

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,12 +52,13 @@ module.exports = {
               else util.log(util.colors.green('Opened ' + url + ' in ' + browsername));
             });
           }
-        })
+        });
     };
   },
   reload: function () {
     return es.map(function (file, callback) {
-      if (opt.livereload) {
+      var o = opt || {};
+      if (o.livereload) {
         lr.changed({
           body: {
             files: file.path


### PR DESCRIPTION
Fixes #16. Creates an empty object if opts has not yet been defined, eliminating the property error when accessing `livereload`.
