### PR TITLE
Problem running tasks without running connect task

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,11 +58,13 @@ module.exports = {
   reload: function () {
     return es.map(function (file, callback) {
       if (o.livereload) {
-        lr.changed({
-          body: {
-            files: file.path
-          }
-        });
+        if (lr) {
+          lr.changed({
+            body: {
+              files: file.path
+            }
+          });
+        }
       } else {
         util.log(util.colors.bgRed('call connect.reload(), livereload is false, enable livereload'));
       }


### PR DESCRIPTION
For example if this task is called without call first the connect task, it throw an error

``` javascript
gulp.task("sass", function () {
  return gulp.src("src/styles/main.scss")
    .pipe(sass())
    .on('error', gutil.log)
    .pipe(gulp.dest("tmp/styles/"))
    .pipe(connect.reload());
});
```

```
[gulp] [TypeError: Cannot call method 'changed' of undefined]
```
