### PR TITLE
fix(package.json): use non-broken connect version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "event-stream": "~3.1.0",
     "connect-livereload": "~0.3.2",
     "tiny-lr": "^0.0.7",
-    "connect": "^2.14.3"
+    "connect": "<2.18.0"
   },
   "devDependencies": {
     "gulp": "~3.5.1",


### PR DESCRIPTION
Connect versions 2.18 and higher cause node to throw an error.
See issue:  https://github.com/AveVlad/gulp-connect/issues/59
Reproduced using node version 0.10.26 and 0.10.28.

Closes: #56
