### PR TITLE
Use the new middleware API

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -21,8 +21,9 @@ class ConnectApp
     @server()
 
   server: ->
-    middleware = @middleware()
-    app = connect.apply(null, middleware)
+    app = connect()
+    @middleware().forEach (middleware) ->
+      app.use middleware
     if opt.https?
       server = https.createServer
         key: opt.https.key || fs.readFileSync __dirname + '/certs/server.key'


### PR DESCRIPTION
This module currently produces the following warning:

```
connect deprecated connect(middleware): use app.use(middleware) instead node_modules/gulp-connect/index.js:39:19
```

This patch fixes the deprecation warning by replacing `connect(middleware)` with `app.use(middleware)`.
