### PR TITLE
Make all connections closed before close the server

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -41,14 +41,23 @@ class ConnectApp
         @log "Server started http://#{opt.host}:#{opt.port}"
         
         stoped = false;
+        sockets = [];
         
         server.on 'close', =>
           if (!stoped)
             stoped = true
             @log "Server stopped"
+
+        server.on "connection", (socket) =>
+          sockets.push socket
+          socket.on "close", =>
+            sockets.splice sockets.indexOf(socket), 1
         
         stopServer = =>
           if (!stoped)
+            sockets.forEach (socket) =>
+              socket.destroy()
+
             server.close()
             process.nextTick( ->
               process.exit(0);


### PR DESCRIPTION
For fix issue https://github.com/AveVlad/gulp-connect/issues/79

When enable livereload option, some connections are not closed before close server. As a result, the server can't be closed successfully and the 'close' event is not emitted. The stopServer() function is called twice, but the stoped variable has not to be set to true. Finally, server.close() are called twice and the error appears.
