### PR TITLE
Expose `lr` object

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     }
   ],
   "scripts": {
-    "test": "mocha"
+    "pretest": "./node_modules/.bin/coffee -o . -bc src/",
+    "postinstall": "./node_modules/.bin/coffee -o . -bc src/",
+    "test": "./node_modules/.bin/mocha"
   },
   "engines": {
     "node": ">=0.10.0"
@@ -47,6 +49,7 @@
     "gulp": "~3.5.1",
     "gulp-stylus": "0.0.11",
     "mocha": "^1.18.2",
-    "supertest": "^0.10.0"
+    "supertest": "^0.10.0",
+    "coffee-script": "^1.0.0"
   }
 }

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -115,4 +115,5 @@ module.exports =
         lr.changed body:
           files: file.path
       callback null, file
+  lr: lr
   serverClose: -> do server.close


### PR DESCRIPTION
I needed to shim the `connect.reload` function a bit but realized it was not possible without having gulp and livereload worlds to clash (even emitter leaks as outcome), so needed access to the `lr` object to monkey-patch the function. Now that was not easy as it was configured within the plugin with certs so instead of reinventing the wheel just exposing the object. Simple fix.

Fixed the package.json while on it, could not make the project tests to run out of the box.

<!---
@huboard:{"order":98.0,"milestone_order":98,"custom_state":""}
-->
