### PR TITLE
Debug request when debug opt = true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 index.js
 *.css
+*.iml

--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ Fallback file (e.g. `index.html`)
 Type: `Function`
 Default: `[]`
 
+#### options.debug
+
+Type: `Boolean`
+Default: `false`
+
+
 ```js
 gulp.task('connect', function() {
   connect.server({

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -17,6 +17,7 @@ class ConnectApp
     opt.port = opt.port || "8080"
     opt.root = opt.root || path.dirname(module.parent.id)
     opt.host = opt.host || "localhost"
+    opt.debug = opt.debug || false
     @oldMethod("open") if opt.open
     @server()
 
@@ -48,10 +49,14 @@ class ConnectApp
             stoped = true
             @log "Server stopped"
 
+        # Log connections and request in debug
         server.on "connection", (socket) =>
           sockets.push socket
           socket.on "close", =>
             sockets.splice sockets.indexOf(socket), 1
+
+        server.on "request", (request, response) =>
+          @logDebug "Received request #{request.method} #{request.url}"
         
         stopServer = =>
           if (!stoped)
@@ -101,6 +106,10 @@ class ConnectApp
   logWarning: (@text) ->
     if !opt.silent
       util.log util.colors.yellow(@text)
+
+  logDebug: (@text) ->
+    if opt.debug
+      util.log util.colors.blue(@text)
 
   oldMethod: (type) ->
     text = 'does not work in gulp-connect v 2.*. Please read "readme" https://github.com/AveVlad/gulp-connect'


### PR DESCRIPTION
Sometimes, in development mode, it's hard to know whether the server is actually receiving requests from the outside world or not. It would be nice to be able to activate some sort of mode debug in order to display the requests that arrive. This PR addresses this problem. 

The proposed solution displays one line (in blue) per request received:

[12:34:02] Received request GET /css/main.css
[12:34:02] Received request GET /bower_components/moment/min/moment-with-locales.js
[12:34:02] Received request GET /bower_components/moment-timezone/builds/moment-timezone-with-data.js
[12:34:02] Received request GET /bower_components/jquery/dist/jquery.js
[12:34:02] Received request GET /bower_components/lodash/dist/lodash.min.js
[12:34:02] Received request GET /bower_components/angular/angular.js
