### PR TITLE
Allow middleware to be passed as an array

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -24,7 +24,7 @@ class ConnectApp
   server: ->
     app = connect()
     @middleware().forEach (middleware) ->
-      if typeof (middleware) is "array"
+      if typeof (middleware) is "object"
         app.use middleware[0], middleware[1]
       else
         app.use middleware


### PR DESCRIPTION
I made this change to my local `gulp-connect`, and others may find it useful. By allowing middleware options to be an array, you can pass routing rules to the underlying connect server like so: 

```
middleware: function() {
        return [
          allRouteMiddleware,
          ['/some/route', someRouteMiddleware]
        ];
      }
```