### PR TITLE
Add tests for node 0.12 and iojs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 node_js:
   - "0.10"
   - "0.11"
-  - "0.10.30"
+  - "0.12"
+  - "iojs"
 before_install:
   - "npm install -g coffee-script"
 before_script:


### PR DESCRIPTION
Because node 0.12 (latest stable release is 0.12.5) and io.js are cool ! :smile: 