### PR TITLE
Log the correct url when the 'https' option is specified.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -39,7 +39,7 @@ class ConnectApp
       if err
         @log "Error on starting server: #{err}"
       else
-        @log "Server started http://#{opt.host}:#{opt.port}"
+        @log "Server started http#{if opt.https? then 's' else ''}://#{opt.host}:#{opt.port}"
         
         stoped = false;
         sockets = [];


### PR DESCRIPTION
Currently, the log entry that outputs the server address has `http://` hard coded. This uses the `opt.https` option to log `https://` when applicable. 