### PR TITLE
Pass livereload options through instead of just the port number

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ Default: `false`
 Type: `Number`
 Default: `35729`
 
+Overrides the hostname of the script livereload injects in index.html
+
+#### options.livereload.hostname
+
+Type: `String`
+Default: 'undefined'
+
 #### options.fallback
 
 Type: `String`

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -90,7 +90,7 @@ class ConnectApp
     if opt.livereload
       opt.livereload = {}  if typeof opt.livereload is "boolean"
       opt.livereload.port = 35729  unless opt.livereload.port
-      middleware.unshift liveReload(port: opt.livereload.port)
+      middleware.unshift liveReload(opt.livereload)
     if typeof opt.root == "object"
       opt.root.forEach (path) ->
         middleware.push connect.static(path)


### PR DESCRIPTION
Needed in some instances where livereload injects wrong hostnames into index.html
As an example this can happen when running in a Docker container.