### PR TITLE
Use HTTP/2 when the http2 package is installed and 'https' option is enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
     "gulp-stylus": "^2.1.1",
     "mocha": "^2.3.4",
     "supertest": "^1.1.0"
+  },
+  "optionalDependencies": {
+    "http2": "^3.3.2"
   }
 }

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -11,6 +11,10 @@ opt = {}
 server = undefined
 lr = undefined
 
+http2 = undefined
+try
+  http2 = require('http2')
+
 class ConnectApp
   constructor: (options) ->
     opt = options
@@ -29,7 +33,7 @@ class ConnectApp
       else
         app.use middleware
     if opt.https?
-      server = https.createServer
+      server = (http2 || https).createServer
         key: opt.https.key || fs.readFileSync __dirname + '/certs/server.key'
         cert: opt.https.cert || fs.readFileSync __dirname + '/certs/server.crt'
         ca: opt.https.ca || fs.readFileSync __dirname + '/certs/ca.crt'


### PR DESCRIPTION
This implements the change described in #157.

Since the API of the two packages is the same, this was quite a small change. Trying it out in Chrome, the main noticeable difference is that a single connection is used.