### PR TITLE
Fixed problem with livereload

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -142,10 +142,11 @@ module.exports =
     app
   reload: ->
     es.map (file, callback) ->
-      if @livereload and typeof lr == "object"
-        lr.changed body:
-          files: file.path
-      callback null, file
+      apps.forEach (app) =>
+        if app.livereload and typeof lr == "object"
+          lr.changed body:
+            files: file.path
+        callback null, file
   lr: lr
   serverClose: ->
     apps.forEach((app) -> do app.server.close)


### PR DESCRIPTION
I tried to use this plugin to perform livereloading, but it doesn't works by default. There is a small problem with "livereload" option. This little fix solved the problem.