### PR TITLE
Default to index.html

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -32,7 +32,6 @@ class ConnectApp
 
   run: ->
     @app = connect()
-    @app.use connect.directory(if typeof @root == "object" then @root[0] else @root)
 
     @handlers().forEach (middleware) =>
       if typeof (middleware) is "object"

--- a/test/fixtures/simplest/index.html
+++ b/test/fixtures/simplest/index.html
@@ -1,0 +1,1 @@
+index page

--- a/test/test.js
+++ b/test/test.js
@@ -4,17 +4,31 @@ require('mocha');
 
 
 describe('gulp-connect', function () {
-  it('Simple', function (done) {
-    connect.server();
-    request('http://localhost:8080')
-      .get('/fixtures/simplest/test.txt')
-      .expect(/Hello world/)
-      .expect(200)
-      .end(function (err, res) {
-        connect.serverClose();
-        if (err) return done(err);
-        done()
-      });
+  describe('Simple', function() {
+    var req;
+    before(function() {
+      connect.server();
+      req = request('http://localhost:8080');
+    })
+    after(function() {
+      connect.serverClose();
+    })
+    it('Explicit /test.txt', function (done) {
+      req.get('/fixtures/simplest/test.txt')
+        .expect(/Hello world/)
+        .expect(200)
+        .end(function (err, res) {
+          done(err);
+        });
+    })
+    it('Implicit /index.html', function (done) {
+      req.get('/fixtures/simplest/')
+        .expect(/index page/)
+        .expect(200)
+        .end(function (err, res) {
+          done(err);
+        });
+    })
   })
   it('Root string', function (done) {
     connect.server({


### PR DESCRIPTION
fixes https://github.com/AveVlad/gulp-connect/issues/163

Looks like `serve-index` and `serve-static` middlewares clash when used in that order. `serve-static` has the desirable default behavior anyway regarding serving `index.html` files on directory requests, so let's just nix `serve-index` altogether.