### PR TITLE
fix livereload port is not work

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -108,7 +108,7 @@ class ConnectApp
     if @livereload
       @livereload = {}  if typeof @livereload is "boolean"
       @livereload.port = 35729  unless @livereload.port
-      steps.unshift liveReload(@livereload.port)
+      steps.unshift liveReload(@livereload)
     if typeof @root == "object"
       @root.forEach (path) ->
         steps.push connect.static(path)


### PR DESCRIPTION
I found when use liveReload set livereload.port is invalid in gulp-connect.
Because livereload options argument is Object in [connect-livereload](https://github.com/intesso/connect-livereload/blob/master/index.js#L22), but in [gulp-connect](https://github.com/AveVlad/gulp-connect/blob/master/src/index.coffee#L111), the options is Number, so cause livereload port cannot customize.