### PR TITLE
Move reload callback outside of apps loop

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -147,7 +147,7 @@ module.exports =
         if app.livereload and typeof lr == "object"
           lr.changed body:
             files: file.path
-        callback null, file
+      callback null, file
   lr: lr
   serverClose: ->
     apps.forEach((app) -> do app.server.close)


### PR DESCRIPTION
Calling `connect.reload()` with no apps running led to callback never being called. (indentation issue from https://github.com/AveVlad/gulp-connect/commit/0ce1a727ef2a2219dfc2764e7b3343eb0aebe6fd)