### PR TITLE
fix multiple servers bug

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -7,7 +7,6 @@ fs = require("fs")
 connect = require("connect")
 liveReload = require("connect-livereload")
 tiny_lr = require("tiny-lr")
-lr = undefined
 apps = []
 
 http2 = undefined
@@ -28,6 +27,7 @@ class ConnectApp
     @oldMethod("open") if options.open
     @sockets = []
     @app = undefined
+    @lr = undefined
     @run()
 
   run: ->
@@ -103,13 +103,13 @@ class ConnectApp
         if @livereload
           tiny_lr.Server::error = ->
           if @https
-            lr = tiny_lr
+            @lr = tiny_lr
               key: @https.key || fs.readFileSync __dirname + '/certs/server.key'
               cert: @https.cert || fs.readFileSync __dirname + '/certs/server.crt'
           else
-            lr = tiny_lr()
+            @lr = tiny_lr()
 
-          lr.listen @livereload.port
+          @lr.listen @livereload.port
           @log "LiveReload started on port #{@livereload.port}"
 
   handlers: ->
@@ -153,11 +153,10 @@ module.exports =
   reload: ->
     es.map (file, callback) ->
       apps.forEach (app) =>
-        if app.livereload and typeof lr == "object"
-          lr.changed body:
+        if app.livereload and typeof app.lr == "object"
+          app.lr.changed body:
             files: file.path
       callback null, file
-  lr: lr
   serverClose: ->
     apps.forEach((app) -> do app.server.close)
     apps = []


### PR DESCRIPTION
In the former version, creating multiple servers doesn't work.
```
 var gulp = require('gulp'),
  connect = require('gulp-connect');

gulp.task('connectDist', function () {
  connect.server({
    root: 'dist',
    port: 8001,
    livereload: true
  });
});

gulp.task('connectDev', function () {
  connect.server({
    root: ['app'],
    port: 8002,
    livereload: true
  });
});
 

gulp.task('reloadApp', function() {
  gulp.src('./app/**')
    .pipe(connect.reload());
})

gulp.task('reloadDist', function() {
  gulp.src('./dist/**')
    .pipe(connect.reload());
})

gulp.task('watch', function() {
  gulp.watch(['./app/**'], ['reloadApp']);
  gulp.watch(['./dist/**'], ['reloadDist']);
})

gulp.task('default', ['connectDev', 'connectDist', 'watch']);
```
I found it is because` lr `is a global variable and if we create several servers,` lr` will be overwritten.
After I look into the `lr` which is an object return by `tiny-lr` package.When we initialize a `tiny-lr`, its `clients` attribute will be set {}, an empty object.That is why we lose the clients connected before.And when we change the files, the `clients` is empty so the server can't reload the changed files.

So I suggest that we should put lr as a private variable rather than a global one.
Thanks :)