### PR TITLE
Handle possibility to have fallback function instead of string only

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -125,7 +125,13 @@ class ConnectApp
       steps.push connect.static(@root)
     if @fallback
       steps.push (req, res) =>
-        require('fs').createReadStream(@fallback).pipe(res)
+        fallbackPath = @fallback
+
+        if typeof @fallback is "function"
+          fallbackPath = @fallback(req, res)
+
+        require('fs').createReadStream(fallbackPath).pipe(res)
+
     return steps
 
   log: (text) ->


### PR DESCRIPTION
Sometimes my server need to handle more than one fallback depending on the request url.

Depending on the base route I need to retrieve diffferent index.

For example:
./builds/foo/index.html -> localhost:7777/foo
./builds/bar/index.html -> localhost:7777/bar

I have multiple builds for my application foo and bar.

I need to retrieve index from foo directory when my base url contain foo and same for bar.

So to solve this I needed to have a fallback function to change dynamically my path on every request.