### PR TITLE
allowing user to pass a name that will be logged on gulp output

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -15,6 +15,7 @@ try
 
 class ConnectApp
   constructor: (options) ->
+    @name = options.name || "Server"
     @port = options.port || "8080"
     @root = options.root || path.dirname(module.parent.id)
     @host = options.host || "localhost"
@@ -64,7 +65,7 @@ class ConnectApp
       if err
         @log "Error on starting server: #{err}"
       else
-        @log "Server started http#{if @https then 's' else ''}://#{@host}:#{@port}"
+        @log "#{@name} started http#{if @https then 's' else ''}://#{@host}:#{@port}"
 
         stoped = false
         sockets = []
@@ -72,7 +73,7 @@ class ConnectApp
         @server.on "close", =>
           if (!stoped)
             stoped = true
-            @log "Server stopped"
+            @log "#{@name} stopped"
 
         # Log connections and request in debug
         @server.on "connection", (socket) =>


### PR DESCRIPTION
We had multiple libraries logging out multiple lines that looked like

```
Server started http://localhost:8010
Server started http://localhost:8020
Server started http://localhost:8030
```

It can get confusing seeing this, so I've added name to the connect options so now this looks like:

```
Local CDN started http://localhost:8010
Frontend started http://localhost:8020
API started http://localhost:8030
```