### PR TITLE
don't install the http2 package by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ gulp.task('watch', function () {
 gulp.task('default', ['connectDist', 'connectDev', 'watch']);
 ```
 
+#### http2 support
+
+If the [http2](https://www.npmjs.com/package/http2) package is installed and you use an https connection to gulp connect then http 2 will be used in preference to http 1.
+
 ## API
 
 #### options.root

--- a/package.json
+++ b/package.json
@@ -55,8 +55,5 @@
     "gulp-stylus": "^2.1.1",
     "mocha": "^2.3.4",
     "supertest": "^1.1.0"
-  },
-  "optionalDependencies": {
-    "http2": "^3.3.2"
   }
 }


### PR DESCRIPTION
fixes https://github.com/AveVlad/gulp-connect/issues/197

This now means that if you want http2 support you need to install the http2 package, which appears to have been the original intent.

Should probably be regarded as a breaking change though.