### PR TITLE
Use send for fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "connect-livereload": "^0.5.4",
     "event-stream": "^3.3.2",
     "gulp-util": "^3.0.6",
+    "send": "^0.14.1",
     "tiny-lr": "^0.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "connect-livereload": "^0.5.4",
     "event-stream": "^3.3.2",
     "gulp-util": "^3.0.6",
-    "send": "^0.14.1",
+    "send": "^0.13.2",
     "tiny-lr": "^0.2.1"
   },
   "devDependencies": {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -6,6 +6,7 @@ https = require("https")
 fs = require("fs")
 connect = require("connect")
 liveReload = require("connect-livereload")
+send = require("send")
 tiny_lr = require("tiny-lr")
 apps = []
 
@@ -135,7 +136,7 @@ class ConnectApp
         if typeof @fallback is "function"
           fallbackPath = @fallback(req, res)
 
-        require('fs').createReadStream(fallbackPath).pipe(res)
+        send(req, fallbackPath).pipe(res);
 
     return steps
 

--- a/test/test.js
+++ b/test/test.js
@@ -150,11 +150,12 @@ describe('gulp-connect', function () {
   })
   it('Fallback test', function (done) {
     connect.server({
-      fallback: __dirname + '/fixtures/simplest/test.txt'
+      fallback: __dirname + '/fixtures/simplest/index.html'
     });
     request('http://localhost:8080')
       .get('/not/existing/path')
-      .expect(/Hello world/)
+      .expect(/index page/)
+      .expect('Content-Type', new RegExp('text/html; charset=UTF-8'))
       .expect(200)
       .end(function (err, res) {
         connect.serverClose();


### PR DESCRIPTION
Resolves #204 by using the [send](https://www.npmjs.com/package/send) module to set the correct headers on the fallback file response. The send module I use is the same module that serve-static (dep of connect) uses to serve static files.
