### PR TITLE
Get hostname from options.host

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -65,7 +65,7 @@ class ConnectApp
       @server = http.createServer @app
     if @serverInit
       @serverInit @server
-    @server.listen @port, (err) =>
+    @server.listen @port, @host, (err) =>
       if err
         @log "Error on starting server: #{err}"
       else


### PR DESCRIPTION
`options.host` ignored for now (related issue #167)