### PR TITLE
Add support for pfx keys when using https as an object

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -49,7 +49,7 @@ class ConnectApp
 
       # use some defaults when not set. do not touch when a key is already specified
       # see https://github.com/AveVlad/gulp-connect/issues/172
-      if typeof (@https) is 'boolean' || !@https.key
+      if typeof (@https) is 'boolean' || (!@https.key && !@https.pfx)
 
         # change it into an object if it is not already one
         if !(typeof (@https) is "object")


### PR DESCRIPTION
The original solution checked if `@https.key` was set,
which will not be set when the options `pfx` is used.
Quickfix by adding additional check for `@https.pfx`,
note that this will only add support for pfx.