### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The connect webserver port
 Type: `String`
 Default: `localhost`
 
-####options.name
+#### options.name
 
 Type: `String`
 Default: `Server`


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
