### PR TITLE
removed deprecated gulp-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,10 +43,11 @@
     "server"
   ],
   "dependencies": {
+    "ansi-colors": "^1.0.1",
     "connect": "^2.30.0",
     "connect-livereload": "^0.5.4",
     "event-stream": "^3.3.2",
-    "gulp-util": "^3.0.6",
+    "fancy-log": "^1.3.2",
     "send": "^0.13.2",
     "tiny-lr": "^0.2.1"
   },

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,6 +1,7 @@
 path = require("path")
+fancyLog = require("fancy-log")
+colors = require("ansi-colors")
 es = require("event-stream")
-util = require("gulp-util")
 http = require("http")
 https = require("https")
 fs = require("fs")
@@ -142,15 +143,15 @@ class ConnectApp
 
   log: (text) ->
     if !@silent
-      util.log util.colors.green(text)
+      fancyLog colors.green(text)
 
   logWarning: (text) ->
     if !@silent
-      util.log util.colors.yellow(text)
+      fancyLog colors.yellow(text)
 
   logDebug: (text) ->
     if @debug
-      util.log util.colors.blue(text)
+      fancyLog colors.blue(text)
 
   oldMethod: (type) ->
     text = 'does not work in gulp-connect v 2.*. Please read "readme" https://github.com/AveVlad/gulp-connect'


### PR DESCRIPTION
This tool's use of the recently deprecated gulp-util package is causing warnings to be thrown on install. For more info see https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5

Thanks!