### PR TITLE
Only try requiring `http2` if preferHttp1 is false

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -13,10 +13,6 @@ send = require("send")
 tiny_lr = require("tiny-lr")
 apps = []
 
-http2 = undefined
-try
-  http2 = require('http2')
-
 class ConnectApp
   constructor: (options, startedCallback) ->
     @name = options.name || "Server"
@@ -71,7 +67,12 @@ class ConnectApp
         @https.ca         = fs.readFileSync __dirname + '/certs/server.crt'
         @https.passphrase = 'gulp'
 
-      if !@preferHttp1 && http2
+      http2 = undefined
+      if !@preferHttp1
+        try
+          http2 = require('http2')
+
+      if http2
         @https.allowHTTP1 = true
         @server = http2.createSecureServer(@https, @app)
       else


### PR DESCRIPTION
I neglected to change this in my [previous PR](https://github.com/AveVlad/gulp-connect/pull/247), but noticed this when upgrading. Essentially, if you are using Node 8 or 9 and you are using `preferHttp1=true`, then `gulp-connect` is still trying to load the experimental http2 library. This means you get an annoying warning like:

![image](https://user-images.githubusercontent.com/17131271/36514387-0a866dc8-1729-11e8-99d3-490a5b7ab235.png)

Therefore, we should only load the http2 library if preferHttp1 is set to false.

@AveVlad 