### PR TITLE
report any host as localhost

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -86,7 +86,7 @@ class ConnectApp
       if err
         @log "Error on starting server: #{err}"
       else
-        @log "#{@name} started http#{if @https then 's' else ''}://#{@host}:#{@port}"
+        @log "#{@name} started http#{if @https then 's' else ''}://#{if @host == '0.0.0.0' then 'localhost' else @host}:#{@port}"
 
         stoped = false
         sockets = []


### PR DESCRIPTION
To allow the server to be accessed from any IP address in the network neighborhood, the host must be set to 0.0.0.0. However, this value then gets passed passed directly to the log, resulting in the following message:

```
Server started http://0.0.0.0:5000
```

The host in the URL is surprising for less technical users, who expect to see localhost. Therefore, the host value 0.0.0.0 should still be reported as "localhost" in the log message.

If this masking is not acceptable, I'd be open to introducing a "displayHost" option value for this purpose.