### PR TITLE
Updated usage section due to ERR Assertion Gulp v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ gulp.task('connect', function() {
   connect.server();
 });
 
-gulp.task('default', ['connect']);
+gulp.task('default', gulp.series('connect'));
 ```
 
 #### LiveReload


### PR DESCRIPTION
Updated last line of code on usage due to AssertionError [ERR_ASSERTION]: Task function must be specified
This happens as a result of updating to Gulp v4.

['connect'] should be updated to gulp.series('connect') or gulp.parallel('connect')